### PR TITLE
Upgrade Reaper dependency 2.2.5 -> 2.3.0

### DIFF
--- a/.github/workflows/integration-tests-release.yaml
+++ b/.github/workflows/integration-tests-release.yaml
@@ -20,6 +20,14 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      kubernetes_version:
+        description: 'Kubernetes version'     
+        required: true
+        default: 'v1.20.2'
+      tags:
+        description: 'Run integration tests with different versions of K8s' 
 
 jobs:
   build_docker_images:
@@ -95,11 +103,21 @@ jobs:
         with:
           version: ${{ env.HELM_VERSION }}
 
+      - name: Get k8s version
+        env:
+          DEFAULT_K8S_VERSION: v1.20.2
+        run: |
+          if [[ -z "${{ github.event.inputs.kubernetes_version }}" ]]; then
+            echo "K8S_VERSION=$DEFAULT_K8S_VERSION" >> $GITHUB_ENV
+          else
+            echo "K8S_VERSION=${{ github.event.inputs.kubernetes_version }}" >> $GITHUB_ENV
+          fi
+
       - name: Create Kind Cluster
         uses: helm/kind-action@v1.1.0
         with: 
           version: v0.10.0
-          node_image: kindest/node:v1.20.2
+          node_image: kindest/node:${{ env.K8S_VERSION }}
           cluster_name: kind
           config: tests/integration/kind/kind_config_3_workers.yaml
 

--- a/.github/workflows/integration-tests-release.yaml
+++ b/.github/workflows/integration-tests-release.yaml
@@ -77,6 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        k8s_version: [${{ github.event.inputs.kubernetes_version }}]
         cassandra_version: ["3.11.10", "4.0.0"]
         scenario: ["TestMedusaDeploymentScenario/\"S3\"", "TestMedusaDeploymentScenario/\"Minio\"", "TestMedusaDeploymentScenario/\"local\"", "TestReaperDeploymentScenario", "TestMonitoringDeploymentScenario", "TestStargateDeploymentScenario", "TestRestoreAfterUpgrade", "TestUpgradeScenario"]
     steps:

--- a/.github/workflows/integration-tests-release.yaml
+++ b/.github/workflows/integration-tests-release.yaml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [${{ github.event.inputs.kubernetes_version }}]
+        k8s_version: ["${{ github.event.inputs.kubernetes_version }}"]
         cassandra_version: ["3.11.10", "4.0.0"]
         scenario: ["TestMedusaDeploymentScenario/\"S3\"", "TestMedusaDeploymentScenario/\"Minio\"", "TestMedusaDeploymentScenario/\"local\"", "TestReaperDeploymentScenario", "TestMonitoringDeploymentScenario", "TestStargateDeploymentScenario", "TestRestoreAfterUpgrade", "TestUpgradeScenario"]
     steps:

--- a/.github/workflows/k8s_matrix_test.yaml
+++ b/.github/workflows/k8s_matrix_test.yaml
@@ -1,0 +1,23 @@
+---
+name: K8s version test
+
+on:
+  #schedule:
+    # Runs daily at noon UTC (I guess)
+  #  - cron:  '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-integration-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: ["v1.18.20", "v1.19.11", "v1.20.7", "v1.21.2"]
+    steps:
+      - name: Invoke integration tests
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Integration Tests and Release
+          token: ${{ secrets.CREATE_PR_TOKEN }}
+          inputs: '{ "kubernetes_version": "${{ matrix.k8s_version }}" }'

--- a/.github/workflows/k8s_matrix_test.yaml
+++ b/.github/workflows/k8s_matrix_test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: ["v1.18.20", "v1.19.11", "v1.20.7", "v1.21.2"]
+        k8s_version: ["v1.17.17", "v1.18.19", "v1.19.11", "v1.20.7", "v1.21.2"]
     steps:
       - name: Invoke integration tests
         uses: benc-uk/workflow-dispatch@v1

--- a/charts/k8ssandra/values.yaml
+++ b/charts/k8ssandra/values.yaml
@@ -417,7 +417,7 @@ reaper:
     # -- Specifies the container repository for cassandra-reaper
     repository: docker.io/thelastpickle/cassandra-reaper
     # -- Tag of an image within the specified repository
-    tag: 2.2.5
+    tag: 2.3.0
   # -- Configures the Cassandra user used by Reaper when authentication is
   # enabled. If neither cassandraUser.secret nor cassandraUser.username are
   # set, then a Cassandra user and a secret with the user's credentials will
@@ -526,7 +526,6 @@ medusa:
 # The volume can be mounted to pod with different access modes. The available modes depend on the provider and
 # how they're exported in the PersistentVolume definition. The default for these mounts is ReadWriteOnce.
 # accessModes: []
-
 monitoring:
   grafana:
     # -- Enables the creation of configmaps containing Grafana dashboards. If


### PR DESCRIPTION
This is auto-generated update from the K8ssandra upgrade GHA workflow.
Check that CI passes correctly before merging this PR.